### PR TITLE
Standard primitive types in CompactInteger constructor

### DIFF
--- a/Ajuna.NetApi/Ajuna.NetApi.csproj
+++ b/Ajuna.NetApi/Ajuna.NetApi.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<PackageId>Ajuna.NetApi</PackageId>
 		<TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-		<Version>0.1.9</Version>
+		<Version>0.1.10</Version>
 		<Company>BloGa Tech AG</Company>
 		<Authors>Cedric Decoster</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Ajuna.NetApi/CompactInteger.cs
+++ b/Ajuna.NetApi/CompactInteger.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Numerics;
 using Ajuna.NetApi.Model.Types;
+using Ajuna.NetApi.Model.Types.Primitive;
 
 namespace Ajuna.NetApi
 {
@@ -11,10 +12,19 @@ namespace Ajuna.NetApi
         /// <summary> Constructor. </summary>
         /// <remarks> 19.09.2020. </remarks>
         /// <param name="value"> The value. </param>
-        public CompactInteger(BigInteger value)
-        {
-            Value = value;
-        }
+        public CompactInteger(BigInteger value) => Value = value;
+        public CompactInteger(I8 value) => Value = value.Value;
+        public CompactInteger(I16 value) => Value = value.Value;
+        public CompactInteger(I32 value) => Value = value.Value;
+        public CompactInteger(I64 value) => Value = value.Value;
+        public CompactInteger(I128 value) => Value = value.Value;
+        public CompactInteger(I256 value) => Value = value.Value;
+        public CompactInteger(U8 value) => Value = value.Value;
+        public CompactInteger(U16 value) => Value = value.Value;
+        public CompactInteger(U32 value) => Value = value.Value;
+        public CompactInteger(U64 value) => Value = value.Value;
+        public CompactInteger(U128 value) => Value = value.Value;
+        public CompactInteger(U256 value) => Value = value.Value;
 
         /// <summary> Indicates whether this instance and a specified object are equal. </summary>
         /// <remarks> 19.09.2020. </remarks>


### PR DESCRIPTION
Implemented standard primitive types in CompactInteger constructor to make the Ajuna.SDK generator work with multiple standard primitives.