### PR TITLE
Signature mystery

### DIFF
--- a/Ajuna.NetApi.Test/Extrinsic/InstanceTest.cs
+++ b/Ajuna.NetApi.Test/Extrinsic/InstanceTest.cs
@@ -1,0 +1,37 @@
+﻿using Ajuna.NetApi.Model.Extrinsics;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ajuna.NetApi.Test.Extrinsic
+{
+    public class InstanceTest
+    {
+
+        public static string[] Extrinsic = new string[]
+        {
+            // Timestamp set(now) with now = 1673908758014
+            "0x280403000bfea5bcbc8501",
+            // Staking bondExtra(maxAdditional) with maxAditional = 60000000000
+            "0xbd01840021e64ca11afde772615b240dd09ada3fc96e46619b77f9c0ce3dcebc67878939006ac2017f7951358d09ca1c6da63501b8d00dd72703e593b4a0ca924d59360d4968abaf6361999a21943618ce0850f8b5f8dd51c54c772ffccb35ff63208a1d0025012000070107005847f80d",
+            // Balances transferKeepAlive(dest, value)
+            "0x45028400f371affe2fd3ebd6f0a607e983bc8f905cea0ca2668667a229e112b30c5f9bbd0096f3ac43319d2e980db0aaf2b7e5e985055ea87f7b2a91a2ee09a934aef55bad4ec0dfd93e7010bc5dbf290403051ec40d475534df90ce3e1dd8a5b1ab3f7a0e4502cd0e000503001c3ef60163945e2b4602f7c6b27fc1f8e79d7c3430e3518cf63dc8a6ee84e9740700325f9d08"
+        };
+
+        [Test]
+        [TestCaseSource(nameof(Extrinsic))]
+        public void EncodeAndDecodeExtrinsic_ShouldBeEqual(string hex)
+        {
+            var extrinsic = new Model.Extrinsics.Extrinsic(hex, ChargeTransactionPayment.Default());
+
+            var encoded = extrinsic.Encode();
+            var hexFromEncoded = Utils.Bytes2HexString(encoded);
+            var extrinsicFromEncoded = new Model.Extrinsics.Extrinsic(hexFromEncoded, ChargeTransactionPayment.Default());
+
+            Assert.That(encoded, Is.EqualTo(extrinsicFromEncoded.Encode()));
+        }
+    }
+}

--- a/Ajuna.NetApi.Test/Keys/Ed25519Tests.cs
+++ b/Ajuna.NetApi.Test/Keys/Ed25519Tests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Linq;
+using System.Text;
 using Ajuna.NetApi.Model.Types.Base;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using NUnit.Framework;
+using Schnorrkel.Keys;
 
 namespace Ajuna.NetApi.Test.Keys
 {
@@ -104,6 +107,28 @@ namespace Ajuna.NetApi.Test.Keys
             var simpleSign = Chaos.NaCl.Ed25519.Sign(messag2, privateKey);
             var simpleSignStr = Utils.Bytes2HexString(simpleSign);
             Assert.True(Chaos.NaCl.Ed25519.Verify(simpleSign, messag2, publicKey));
+        }
+
+        [Test]
+        public void SignatureVerifySignedOnNodeByAccount2()
+        {
+            var rawSeed = "0x70f93a75dbc6ad5b0c051210704a00a9937732d0c360792b0fea24efb8ea8465";
+
+            byte[] pubKey, priKey;
+            Chaos.NaCl.Ed25519.KeyPairFromSeed(out pubKey, out priKey, Utils.HexToByteArray(rawSeed));
+
+
+            var message = "I test this signature!";
+            var messageBytes = Encoding.UTF8.GetBytes(message);
+
+            var signature = Chaos.NaCl.Ed25519.Sign(messageBytes, priKey);
+            var singatureHexString = Utils.Bytes2HexString(signature);
+
+            // SIGn C#: 0x679FA7BC8B2A7C40B5ECD50CA041E961DB8971D2B454DB7DE64E543B3C1892A6D3F223DDA01C66B9878C149CFCC8B86ECF2B20F11F7610596F51479405776907
+
+            // SIGn PolkaJS:0xd2baabb61bcd0026e797136cb0938d55e3c3ea8825c163eb3d1738b3c79af8e8f4953ba4767dc5477202756d3fba97bc50fc3ac8355ff5acfba88a36311f2f0f
+            var testSign = "0xd2baabb61bcd0026e797136cb0938d55e3c3ea8825c163eb3d1738b3c79af8e8f4953ba4767dc5477202756d3fba97bc50fc3ac8355ff5acfba88a36311f2f0f";
+            Assert.True(Chaos.NaCl.Ed25519.Verify(Utils.HexToByteArray(testSign), messageBytes, pubKey));
         }
 
         [Test]

--- a/Ajuna.NetApi.Test/Keys/Ed25519Tests.cs
+++ b/Ajuna.NetApi.Test/Keys/Ed25519Tests.cs
@@ -2,8 +2,10 @@ using System;
 using System.Linq;
 using System.Text;
 using Ajuna.NetApi.Model.Types.Base;
+using Ajuna.NetApi.Sign;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 using Schnorrkel.Keys;
 
 namespace Ajuna.NetApi.Test.Keys
@@ -110,7 +112,8 @@ namespace Ajuna.NetApi.Test.Keys
         }
 
         [Test]
-        public void SignatureVerifySignedOnNodeByAccount2()
+        [TestCase("0xd2baabb61bcd0026e797136cb0938d55e3c3ea8825c163eb3d1738b3c79af8e8f4953ba4767dc5477202756d3fba97bc50fc3ac8355ff5acfba88a36311f2f0f")]
+        public void SignatureVerifySignedOnNodeByAccountComparePolkadotJs(string polkadotJsSignature)
         {
             var rawSeed = "0x70f93a75dbc6ad5b0c051210704a00a9937732d0c360792b0fea24efb8ea8465";
 
@@ -119,7 +122,8 @@ namespace Ajuna.NetApi.Test.Keys
 
 
             var message = "I test this signature!";
-            var messageBytes = Encoding.UTF8.GetBytes(message);
+            // According to https://github.com/polkadot-js/apps/blob/master/packages/page-signing/src/Sign.tsx#L93
+            var messageBytes = WrapMessage.Wrap(message);
 
             var signature = Chaos.NaCl.Ed25519.Sign(messageBytes, priKey);
             var singatureHexString = Utils.Bytes2HexString(signature);
@@ -127,8 +131,7 @@ namespace Ajuna.NetApi.Test.Keys
             // SIGn C#: 0x679FA7BC8B2A7C40B5ECD50CA041E961DB8971D2B454DB7DE64E543B3C1892A6D3F223DDA01C66B9878C149CFCC8B86ECF2B20F11F7610596F51479405776907
 
             // SIGn PolkaJS:0xd2baabb61bcd0026e797136cb0938d55e3c3ea8825c163eb3d1738b3c79af8e8f4953ba4767dc5477202756d3fba97bc50fc3ac8355ff5acfba88a36311f2f0f
-            var testSign = "0xd2baabb61bcd0026e797136cb0938d55e3c3ea8825c163eb3d1738b3c79af8e8f4953ba4767dc5477202756d3fba97bc50fc3ac8355ff5acfba88a36311f2f0f";
-            Assert.True(Chaos.NaCl.Ed25519.Verify(Utils.HexToByteArray(testSign), messageBytes, pubKey));
+            Assert.True(Chaos.NaCl.Ed25519.Verify(Utils.HexToByteArray(polkadotJsSignature), messageBytes, pubKey));
         }
 
         [Test]

--- a/Ajuna.NetApi.Test/Keys/Sr25519Tests.cs
+++ b/Ajuna.NetApi.Test/Keys/Sr25519Tests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using Ajuna.NetApi.Sign;
 using NUnit.Framework;
 using Schnorrkel.Keys;
 
@@ -66,20 +67,21 @@ namespace Ajuna.NetApi.Test.Keys
         }
 
         [Test]
-        public void Sr25519SignatureTest2()
+        [TestCase("0x5c42ac4e2d55b8e59d9b255af370de03fe177f5545eecbbd784531cb2eb1f2553e0e2b91656f99fae930eb6ff8ac1a3eca4e19d307ecb39832a479a478a8608a")]
+        public void Sr25519SignatureTestComparePolkadotJs(string polkadotJsSignature)
         {
             var miniSecretAlice = new MiniSecret(Utils.HexToByteArray("0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a"), ExpandMode.Ed25519);
             var keyPairAlice = miniSecretAlice.GetPair();
 
             var message = "I test this signature!";
-            var messageBytes = Encoding.UTF8.GetBytes(message);
+            var messageBytes = WrapMessage.Wrap(message);
 
             var simpleSign = Schnorrkel.Sr25519v091.SignSimple(keyPairAlice, messageBytes);
             var singatureHexString = Utils.Bytes2HexString(simpleSign);
             // SIGn C#: 0x2A6346A8707A9929B65167C448F719FE977F2EE04D2CB250685C98C79CCBF2458901F9B386D08422D9102FBD8BF7CFECDF7605F4CDC5FA8D121E2E9730F9098C
 
             // SIGn PolkaJS:0x5c42ac4e2d55b8e59d9b255af370de03fe177f5545eecbbd784531cb2eb1f2553e0e2b91656f99fae930eb6ff8ac1a3eca4e19d307ecb39832a479a478a8608a
-            var simpleSign2 = Utils.HexToByteArray("0x5c42ac4e2d55b8e59d9b255af370de03fe177f5545eecbbd784531cb2eb1f2553e0e2b91656f99fae930eb6ff8ac1a3eca4e19d307ecb39832a479a478a8608a");
+            var simpleSign2 = Utils.HexToByteArray(polkadotJsSignature);
             Assert.True(Schnorrkel.Sr25519v091.Verify(simpleSign2, keyPairAlice.Public.Key, messageBytes));
         }
 

--- a/Ajuna.NetApi.Test/Keys/Sr25519Tests.cs
+++ b/Ajuna.NetApi.Test/Keys/Sr25519Tests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using NUnit.Framework;
 using Schnorrkel.Keys;
 
@@ -62,6 +63,24 @@ namespace Ajuna.NetApi.Test.Keys
             var simpleSign = Schnorrkel.Sr25519v091.SignSimple(keyPairAlice, message);
 
             Assert.True(Schnorrkel.Sr25519v091.Verify(simpleSign, keyPairAlice.Public.Key, message));
+        }
+
+        [Test]
+        public void Sr25519SignatureTest2()
+        {
+            var miniSecretAlice = new MiniSecret(Utils.HexToByteArray("0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a"), ExpandMode.Ed25519);
+            var keyPairAlice = miniSecretAlice.GetPair();
+
+            var message = "I test this signature!";
+            var messageBytes = Encoding.UTF8.GetBytes(message);
+
+            var simpleSign = Schnorrkel.Sr25519v091.SignSimple(keyPairAlice, messageBytes);
+            var singatureHexString = Utils.Bytes2HexString(simpleSign);
+            // SIGn C#: 0x2A6346A8707A9929B65167C448F719FE977F2EE04D2CB250685C98C79CCBF2458901F9B386D08422D9102FBD8BF7CFECDF7605F4CDC5FA8D121E2E9730F9098C
+
+            // SIGn PolkaJS:0x5c42ac4e2d55b8e59d9b255af370de03fe177f5545eecbbd784531cb2eb1f2553e0e2b91656f99fae930eb6ff8ac1a3eca4e19d307ecb39832a479a478a8608a
+            var simpleSign2 = Utils.HexToByteArray("0x5c42ac4e2d55b8e59d9b255af370de03fe177f5545eecbbd784531cb2eb1f2553e0e2b91656f99fae930eb6ff8ac1a3eca4e19d307ecb39832a479a478a8608a");
+            Assert.True(Schnorrkel.Sr25519v091.Verify(simpleSign2, keyPairAlice.Public.Key, messageBytes));
         }
 
         [Test]

--- a/Ajuna.NetApi.Test/Keys/WrapMessageTest.cs
+++ b/Ajuna.NetApi.Test/Keys/WrapMessageTest.cs
@@ -1,0 +1,64 @@
+﻿using Ajuna.NetApi.Sign;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ajuna.NetApi.Test.Keys
+{
+    public class WrapMessageTest
+    {
+        [Test]
+        [TestCase("<Bytes>test</Bytes>")]
+        [TestCase("<Bytes><byte>AlmostInception</byte></Bytes>")]
+        public void MessageWrapped_ShouldBeDetected(string message)
+        {
+            Assert.That(WrapMessage.IsWrapped(message), Is.True);
+        }
+
+        [Test]
+        [TestCase("IamNotWrapped")]
+        [TestCase("<Byte>almostwrapped</Bytes>")]
+        [TestCase("<bytes>casesentitive</bytes>")]
+        public void UnwrapMessage_ShouldBeDetected(string message)
+        {
+            Assert.That(WrapMessage.IsWrapped(message), Is.False);
+        }
+
+        [Test]
+        public void UnwrapMessage_ShouldBeWrapped()
+        {
+            var message = "test";
+            var messageWrapped = new byte[]
+            {
+                60, 66, 121, 116, 101, 115, 62, 116, 101, 115, 116, 60, 47, 66, 121, 116, 101, 115, 62
+            };
+
+            Assert.That(WrapMessage.IsWrapped(message), Is.False);
+            Assert.That(WrapMessage.Wrap(message), Is.EqualTo(messageWrapped));
+        }
+
+        [Test]
+        public void WrapMessage_ShouldBeUnwrap()
+        {
+            var message = "<Bytes>test</Bytes>";
+            var messageUnwrapped = new byte[]
+            {
+                116, 101, 115, 116
+            };
+
+            Assert.That(WrapMessage.IsWrapped(message), Is.True);
+            Assert.That(WrapMessage.Unwrap(message), Is.EqualTo(messageUnwrapped));
+        }
+
+        [Test]
+        public void MultipleWrapAndUnwrap_ShouldBeUntouched()
+        {
+            var message = "IAmAMessage";
+            Assert.That(WrapMessage.Wrap(WrapMessage.Wrap(WrapMessage.Wrap(WrapMessage.Wrap(message)))), Is.EqualTo(WrapMessage.Wrap(message)));
+            Assert.That(WrapMessage.Unwrap(WrapMessage.Unwrap(WrapMessage.Unwrap(WrapMessage.Unwrap(message)))), Is.EqualTo(WrapMessage.Unwrap(message)));
+        }
+    }
+}

--- a/Ajuna.NetApi/Model/Extrinsics/Extrinsic.cs
+++ b/Ajuna.NetApi/Model/Extrinsics/Extrinsic.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Ajuna.NetApi.Model.Types;
 using Newtonsoft.Json;
 
@@ -125,6 +126,31 @@ namespace Ajuna.NetApi.Model.Extrinsics
             Nonce = nonce;
             Charge = charge;
             Method = method;
+        }
+
+        public byte[] Encode()
+        {
+            var result = new List<byte>();
+
+            var signatureVersion = (byte)((Signed ? 0x80 : 0x00) + TransactionVersion);
+            result.Add(signatureVersion);
+
+            if (Signed)
+            {
+                result.AddRange(Account.Encode());
+                result.Add(Account.KeyTypeByte);
+                result.AddRange(Signature);
+                result.AddRange(Era.Encode());
+                result.AddRange(Nonce.Encode());
+                result.AddRange(Charge.Encode());
+            }
+
+            result.AddRange(Method.Encode());
+
+            var length = new CompactInteger(result.Count);
+            result.InsertRange(0, length.Encode());
+
+            return result.ToArray();
         }
 
         public override string ToString()

--- a/Ajuna.NetApi/Sign/WrapMessage.cs
+++ b/Ajuna.NetApi/Sign/WrapMessage.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ajuna.NetApi.Sign
+{
+    /// <summary>
+    /// According to Polkadot JS common util (https://github.com/polkadot-js/common/blob/master/packages/util/src/u8a/wrap.ts)
+    /// Message to be signed might be wrapped
+    /// 
+    /// TODO : @Darkfriend77 do you want to manage ethereum wrapping message ?
+    /// </summary>
+    public class WrapMessage
+    {
+        private const string U8A_WRAP_PREFIX_STR = "<Bytes>";
+        private const string U8A_WRAP_POSTFIX_STR = "</Bytes>";
+        private static byte[] U8A_WRAP_PREFIX { get; } = Encoding.UTF8.GetBytes(U8A_WRAP_PREFIX_STR);
+        private static byte[] U8A_WRAP_POSTFIX { get; } = Encoding.UTF8.GetBytes(U8A_WRAP_POSTFIX_STR);
+
+        private static int wrapLength = U8A_WRAP_PREFIX.Length + U8A_WRAP_POSTFIX.Length;
+
+        /// <summary>
+        /// Check if data is wrapped by <see cref="U8A_WRAP_PREFIX_STR"/> and <see cref="U8A_WRAP_POSTFIX_STR"/>
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+
+        public static bool IsWrapped(byte[] data)
+        {
+            if (data == null)
+                throw new ArgumentNullException($"{nameof(data)}");
+
+            return data.Length >= wrapLength &&
+                (data.Take(U8A_WRAP_PREFIX.Length).SequenceEqual(U8A_WRAP_PREFIX) &&
+                data.Skip(data.Length - U8A_WRAP_POSTFIX.Length).Take(U8A_WRAP_POSTFIX.Length).SequenceEqual(U8A_WRAP_POSTFIX));
+        }
+        public static bool IsWrapped(string data) => IsWrapped(Encoding.UTF8.GetBytes(data));
+
+        /// <summary>
+        /// Remove <see cref="U8A_WRAP_PREFIX_STR"/> and <see cref="U8A_WRAP_POSTFIX_STR"/> from given data.
+        /// Return data unmodified if already unwrapped
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static byte[] Unwrap(byte[] data)
+        {
+            if (data == null)
+                throw new ArgumentNullException($"{nameof(data)}");
+
+            return IsWrapped(data) ?
+                data
+                    .Skip(U8A_WRAP_PREFIX.Length)
+                    .Take(data.Length - wrapLength)
+                    .ToArray() :
+                data;
+        }
+        public static byte[] Unwrap(string data) => Unwrap(Encoding.UTF8.GetBytes(data));
+
+        /// <summary>
+        /// Wrap data with <see cref="U8A_WRAP_PREFIX_STR"/> and <see cref="U8A_WRAP_POSTFIX_STR"/>
+        /// Return data unmodified if already wrapped 
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static byte[] Wrap(byte[] data)
+        {
+            if (data == null)
+                throw new ArgumentNullException($"{nameof(data)}");
+
+            return IsWrapped(data) ? 
+                data : 
+                U8A_WRAP_PREFIX
+                .Concat(data)
+                .Concat(U8A_WRAP_POSTFIX)
+                .ToArray();
+        }
+        public static byte[] Wrap(string data) => Wrap(Encoding.UTF8.GetBytes(data));
+    }
+}


### PR DESCRIPTION
Hello Cedric,

The bug of Ed25519 and Sr25519 signature when we was not able to verify signature from Polkadot JS was due to a wrapping they did. 
They forced to wrap the message (https://github.com/polkadot-js/apps/blob/master/packages/page-signing/src/Sign.tsx#L93)

Basically, they add "<Bytes>XXXX</Bytes>" to message to sign.
And when they verify signature, they first try to sign the message, and if it does not work, they try with the wrapped message (you can check this function https://github.com/polkadot-js/common/blob/master/packages/util-crypto/src/signature/verify.ts#L90)

So I have added a WrapMessage class which wrap and unwrap message in order to do the same thing.
Have a good evening :)