### PR TITLE
Feature/type size equals

### DIFF
--- a/Ajuna.NetApi.Test/TypeConverters/BaseTypesTest.cs
+++ b/Ajuna.NetApi.Test/TypeConverters/BaseTypesTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Ajuna.NetApi.Model.Types.Base;
 using Ajuna.NetApi.Model.Types.Primitive;
 using NUnit.Framework;
@@ -7,41 +8,60 @@ namespace Ajuna.NetApi.Test
 {
     public class BaseTypesTest
     {
+        /*
+         * Note : I use on purpose Assert.IsTrue(x.Equals(y)) instead of Assert.AreEqual(x, y)
+         * because the green tick "n/n passing" on the Equals method and it's easier to navigate throw the code 
+         */
+
         [Test]
         public void BaseTupleTest()
         {
-            var t1 = new BaseTuple<Ajuna.NetApi.Model.Types.Primitive.U16>();
+            var u16Param = new U16(42);
+
+            var t1 = new BaseTuple<U16>();
             t1.Create("0x2a00");
             Assert.AreEqual(1, t1.Value.Length);
+            Assert.IsTrue(t1.Equals(new BaseTuple<U16>(u16Param)));
 
-            var t2 = new BaseTuple<Ajuna.NetApi.Model.Types.Primitive.U16, Ajuna.NetApi.Model.Types.Primitive.U16>();
+            var t2 = new BaseTuple<U16, U16>();
             t2.Create("0x2a002a00");
             Assert.AreEqual(2, t2.Value.Length);
+            Assert.IsTrue(t2.Equals(new BaseTuple<U16, U16>(u16Param, u16Param)));
 
-            var t3 = new BaseTuple<Ajuna.NetApi.Model.Types.Primitive.U16, Ajuna.NetApi.Model.Types.Primitive.U16, Ajuna.NetApi.Model.Types.Primitive.U16>();
+            var t3 = new BaseTuple<U16, U16, U16>();
             t3.Create("0x2a002a002a00");
             Assert.AreEqual(3, t3.Value.Length);
+            Assert.IsTrue(t3.Equals(new BaseTuple<U16, U16, U16>(u16Param, u16Param, u16Param)));
+
+            var t4 = new BaseTuple<U16, U16, U16>();
+            t4.Create(u16Param, u16Param, u16Param);
+
+            Assert.IsFalse(t2.Equals(t4));
+            Assert.IsTrue(t3.Equals(t4));
         }
 
         [Test]
         public void BaseTupleCreateTest()
         {
-            var u16 = new Ajuna.NetApi.Model.Types.Primitive.U16();
+            var u16 = new U16();
             u16.Create("0x2a00");
 
-            var u32 = new Ajuna.NetApi.Model.Types.Primitive.U32();
+            var u32 = new U32();
             u32.Create("0xffffff00");
 
-            var tupleOfTwo_1 = new BaseTuple<Ajuna.NetApi.Model.Types.Primitive.U16, Ajuna.NetApi.Model.Types.Primitive.U32>();
+            var tupleOfTwo_1 = new BaseTuple<U16, U32>();
             tupleOfTwo_1.Create(u16, u32);
 
             Assert.AreEqual("0x2A00FFFFFF00", Utils.Bytes2HexString(tupleOfTwo_1.Encode()));
+            Assert.IsTrue(tupleOfTwo_1.Equals(new BaseTuple<U16, U32>(u16, u32)));
 
-            var tupleOfTwo_2 = new BaseTuple<Ajuna.NetApi.Model.Types.Primitive.U16, Ajuna.NetApi.Model.Types.Primitive.U32>();
+            var tupleOfTwo_2 = new BaseTuple<U16, U32>();
             tupleOfTwo_2.Create("0x2A00FFFFFF00");
 
-            Assert.AreEqual(u16.Value, ((Ajuna.NetApi.Model.Types.Primitive.U16)tupleOfTwo_2.Value[0]).Value);
-            Assert.AreEqual(u32.Value, ((Ajuna.NetApi.Model.Types.Primitive.U32)tupleOfTwo_2.Value[1]).Value);
+            Assert.AreEqual(u16.Value, ((U16)tupleOfTwo_2.Value[0]).Value);
+            Assert.AreEqual(u32.Value, ((U32)tupleOfTwo_2.Value[1]).Value);
+
+            Assert.IsTrue(tupleOfTwo_1.Equals(tupleOfTwo_2));
         }
 
         [Test]
@@ -49,25 +69,69 @@ namespace Ajuna.NetApi.Test
         {
             // vec u16 test
             var vecUInt16 = new uint[] { 4, 8, 15, 16, 23, 42 };
-            var baseVec = new BaseVec<Ajuna.NetApi.Model.Types.Primitive.U16>();
+            var baseVec = new BaseVec<U16>();
             baseVec.Create("0x18040008000f00100017002a00");
             for (int i = 0; i < vecUInt16.Length; i++)
             {
                 Assert.AreEqual(vecUInt16[i], baseVec.Value[i].Value);
             }
+
+            var baseVecCtor = new BaseVec<U16>(vecUInt16.Select(x => new U16((ushort)x)).ToArray());
+            Assert.IsTrue(baseVec.Equals(baseVecCtor));
+
+            // Just add an other value at the end and check equality fail
+            var baseVecCtor_2 = new BaseVec<U16>(
+                new uint[] { 4, 8, 15, 16, 23, 42, 100 }.Select(x => new U16((ushort)x)).ToArray());
+            Assert.IsFalse(baseVecCtor.Equals(baseVecCtor_2));
+        }
+
+        [Test]
+        public void BaseOptTest()
+        {
+            var baseOptEmpty = new BaseOpt<U32>();
+            Assert.That(baseOptEmpty.OptionFlag, Is.EqualTo(false));
+            Assert.That(baseOptEmpty.Value, Is.Null);
+
+            var expectedOutput = new U64(100);
+            var baseOptFilled = new BaseOpt<U64>();
+            baseOptFilled.Create("0x016400000000000000");
+            Assert.That(baseOptFilled.OptionFlag, Is.EqualTo(true));
+            Assert.That(baseOptFilled.Value, Is.EqualTo(expectedOutput));
+
+            var baseOptFilledWithValue = new BaseOpt<U64>();
+            baseOptFilledWithValue.Create(expectedOutput);
+            Assert.IsTrue(baseOptFilled.Equals(baseOptFilledWithValue));
+
+            var baseOptFilledCtor = new BaseOpt<U64>(expectedOutput);
+            Assert.That(baseOptFilledCtor.OptionFlag, Is.EqualTo(baseOptFilled.OptionFlag));
+            Assert.IsTrue(baseOptFilledCtor.Equals(baseOptFilled));
+
+            // Test case with Option flag = false while data are set
+            var baseOptFilledError = new BaseOpt<U64>();
+            baseOptFilledError.Create("0x006400000000000000");
+            Assert.That(baseOptFilledError.OptionFlag, Is.EqualTo(false));
+            Assert.That(baseOptFilledError.Bytes, Is.Not.Null);
+            Assert.That(baseOptFilledError.Bytes.Length, Is.EqualTo(1));
         }
 
         [Test]
         public void BaseBitSeqTest()
         {
+            var testCase1 = "0xa00b80050000";
             var bitSeqTest1 = FromBitString("0b11010000_00000001_10100000_00000000_00000000");
             var baseBitSeq1 = new BaseBitSeq<U8, U8>();
-            baseBitSeq1.Create("0xa00b80050000");
+            baseBitSeq1.Create(testCase1);
             for (int i = 0; i < bitSeqTest1.Length; i++)
             {
                 Assert.AreEqual(bitSeqTest1[i], baseBitSeq1.Value[i].Value);
             }
-            Assert.AreEqual("0xa00b80050000", Utils.Bytes2HexString(baseBitSeq1.Encode()).ToLower());
+            Assert.AreEqual(testCase1, Utils.Bytes2HexString(baseBitSeq1.Encode()).ToLower());
+
+            // Let's create the same object but with the other Create() method
+            var baseBitSeq1_1 = new BaseBitSeq<U8, U8>();
+            baseBitSeq1_1.Create(baseBitSeq1.Value);
+            
+            Assert.IsTrue(baseBitSeq1.Equals(baseBitSeq1_1));
 
             var bitSeqTest2 = FromBitString("0b10000010_10000010_00101000_00000000_00000000");
             var baseBitSeq2 = new BaseBitSeq<U8, U8>();
@@ -77,6 +141,8 @@ namespace Ajuna.NetApi.Test
                 Assert.AreEqual(bitSeqTest2[i], baseBitSeq2.Value[i].Value);
             }
             Assert.AreEqual("0xa04141140000", Utils.Bytes2HexString(baseBitSeq2.Encode()).ToLower());
+
+            //
         }
 
         private byte[] FromBitString(string str)
@@ -88,6 +154,53 @@ namespace Ajuna.NetApi.Test
                 result[i] = Convert.ToByte(s[i], 2);
             }
             return result;
+        }
+
+        [Test]
+        public void BaseComTest()
+        {
+            var baseComFromCtor = new BaseCom<U64>(new CompactInteger(new U64(10)));
+
+            var baseComFromValue = new BaseCom<U64>();
+            baseComFromValue.Create(new CompactInteger(new U64(10)));
+
+            var baseComFromBytes = new BaseCom<U64>();
+            baseComFromBytes.Create(new byte[] { 40 });
+
+            var baseComFromHex = new BaseCom<U64>();
+            baseComFromHex.Create("0x28");
+
+            Assert.IsTrue(baseComFromValue.Equals(baseComFromCtor));
+            Assert.IsTrue(baseComFromValue.Equals(baseComFromBytes));
+            Assert.IsTrue(baseComFromValue.Equals(baseComFromHex));
+
+            Assert.IsFalse(baseComFromValue.Equals(new BaseCom<U64>(new CompactInteger(new U64(20)))));
+        }
+
+        public enum PartialBalanceEvents
+        {
+
+            Endowed = 0,
+            DustLost = 1,
+            Transfer = 2,
+            BalanceSet = 3,
+        }
+
+        [Test]
+        public void BaseEnumTest()
+        {
+            var baseEnumFromValue = new BaseEnum<PartialBalanceEvents>();
+            baseEnumFromValue.Create(PartialBalanceEvents.Transfer);
+
+            var baseEnumFromBytes = new BaseEnum<PartialBalanceEvents>();
+            baseEnumFromBytes.Create(new byte[] { 2 });
+
+            var baseEnumFromHex = new BaseEnum<PartialBalanceEvents>();
+            baseEnumFromHex.Create("0x02");
+
+            Assert.IsTrue(baseEnumFromValue.Equals(baseEnumFromBytes));
+            Assert.IsTrue(baseEnumFromValue.Equals(baseEnumFromHex));
+            Assert.IsFalse(baseEnumFromValue.Equals(new BaseEnum<PartialBalanceEvents>(PartialBalanceEvents.BalanceSet)));
         }
 
         [Test]
@@ -112,6 +225,50 @@ namespace Ajuna.NetApi.Test
             var hashPrim = new Hash(blockHash);
 
             Assert.AreEqual(hash.Bytes, hashPrim.Bytes);
+        }
+
+        [Test]
+        public void BaseTypeEqualityTest()
+        {
+            var u32_1 = new U32(10);
+            var u32_2 = new U32(10);
+            var u32_3 = new U32(20);
+
+            Assert.IsTrue(u32_1.Equals(u32_2));
+            Assert.IsFalse(u32_1.Equals(u32_3));
+
+            var u64_1 = new U64(10);
+            var u64_2 = new U64(10);
+            var u64_3 = new U64(20);
+
+            Assert.IsTrue(u64_1.Equals(u64_2));
+            Assert.IsTrue(u64_1.Equals(u64_2));
+            Assert.IsFalse(u32_1.Equals(u64_1));
+            Assert.IsFalse(u64_1.Equals(u64_3));
+
+            Assert.IsTrue(new BaseOpt<U32>(new U32(1)).Equals(new BaseOpt<U32>(new U32(1))));
+            Assert.IsTrue(new BaseVec<U32>(
+                new U32[] { new U32(1)
+                }).Equals(new BaseVec<U32>(
+                    new U32[] { new U32(1)
+                    })));
+        }
+
+        [Test]
+        public void BaseTypeEqualityWithNullBytes()
+        {
+            var baseTuple_1 = new BaseTuple<U32, U32>();
+            var baseTuple_2 = new BaseTuple<U32, U32>();
+
+            // Bytes null, but should be equal
+            Assert.That(baseTuple_1.Bytes, Is.Null);
+            Assert.That(baseTuple_1, Is.EqualTo(baseTuple_2));
+
+            var baseVec_1 = new BaseVec<U32>();
+            Assert.That(baseTuple_1, Is.Not.EqualTo(baseVec_1));
+
+            Assert.That(new BaseOpt<U32>(), Is.EqualTo(new BaseOpt<U32>()));
+            Assert.That(new BaseVec<U32>(), Is.EqualTo(new BaseVec<U32>()));
         }
     }
 }

--- a/Ajuna.NetApi.Test/TypeConverters/PrimitiveTypesTest.cs
+++ b/Ajuna.NetApi.Test/TypeConverters/PrimitiveTypesTest.cs
@@ -146,6 +146,10 @@ namespace Ajuna.NetApi.Test
 
             var primCtor = new U128(number);
             Assert.AreEqual(prim.Value, primCtor.Value);
+
+            // 0 is a valid input
+            var primZero = new U128(0);
+            Assert.That(primZero.Value, Is.EqualTo(BigInteger.Zero));
         }
 
         [Test]
@@ -165,6 +169,10 @@ namespace Ajuna.NetApi.Test
 
             var primCtor = new U256(bigNumber);
             Assert.AreEqual(prim.Value, primCtor.Value);
+
+            // 0 is a valid input
+            var primZero = new U256(0);
+            Assert.That(primZero.Value, Is.EqualTo(BigInteger.Zero));
         }
 
         [Test]

--- a/Ajuna.NetApi.Test/TypeConverters/TypeEncodingTest.cs
+++ b/Ajuna.NetApi.Test/TypeConverters/TypeEncodingTest.cs
@@ -128,6 +128,24 @@ namespace Ajuna.NetApi.Test
         }
 
         [Test]
+        public void ExtEnumCreateTest()
+        {
+            var u8 = new U8(1);
+
+            var vecExtEnumTypeFromCreateByteArray = new BaseEnumExt<PhaseState, U8>();
+            vecExtEnumTypeFromCreateByteArray.Create(new byte[] { 0, 1 });
+
+            var vecExtEnumTypeFromCreateHex = new BaseEnumExt<PhaseState, U8>();
+            vecExtEnumTypeFromCreateHex.Create("0x0001");
+
+            var vecExtEnumTypeFromCreateValue = new BaseEnumExt<PhaseState, U8>();
+            vecExtEnumTypeFromCreateValue.Create(PhaseState.None, u8);
+
+            Assert.IsTrue(vecExtEnumTypeFromCreateByteArray.Equals(vecExtEnumTypeFromCreateHex));
+            Assert.IsTrue(vecExtEnumTypeFromCreateHex.Equals(vecExtEnumTypeFromCreateValue));
+        }
+
+        [Test]
         public void ExtEnumXXX()
         {
             var vecExtEnumType = new BaseVec<BaseEnumExt<PhaseState, BaseTuple<Arr4U8, BaseVec<U8>>, BaseVoid, BaseVoid, BaseVoid, BaseVoid, BaseVoid, BaseVoid, BaseVoid, BaseVoid>>();

--- a/Ajuna.NetApi/Model/Types/Base/BaseCom.cs
+++ b/Ajuna.NetApi/Model/Types/Base/BaseCom.cs
@@ -1,7 +1,17 @@
-﻿namespace Ajuna.NetApi.Model.Types.Base
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ajuna.NetApi.Model.Types.Base
 {
     public class BaseCom<T> : BaseType where T : IType, new()
     {
+        public BaseCom() { }
+        public BaseCom(CompactInteger compactInteger)
+        {
+            Create(compactInteger);
+        }
+
         public override string TypeName() => $"Compact<{new T().TypeName()}>";
 
         public override byte[] Encode()
@@ -24,6 +34,8 @@
         {
             Value = compactInteger;
             Bytes = Encode();
+
+            TypeSize = Bytes?.Length ?? 0;
         }
     }
 }

--- a/Ajuna.NetApi/Model/Types/Base/BaseEnum.cs
+++ b/Ajuna.NetApi/Model/Types/Base/BaseEnum.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -6,6 +7,12 @@ namespace Ajuna.NetApi.Model.Types.Base
 {
     public class BaseEnum<T> : IType where T : System.Enum
     {
+        public BaseEnum() { }
+        public BaseEnum(T t)
+        {
+            Create(t);
+        }
+
         public string TypeName() => typeof(T).Name;
 
         public int TypeSize { get; set; } = 1;
@@ -45,6 +52,21 @@ namespace Ajuna.NetApi.Model.Types.Base
         public IType New() => this;
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is BaseEnum<T>) || !obj.GetType().Equals(this.GetType()))
+                return false;
+
+            var baseVec = (BaseEnum<T>)obj;
+            return TypeSize == baseVec.TypeSize &&
+                   (Bytes == null && baseVec.Bytes == null || Bytes.SequenceEqual(baseVec.Bytes));
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(TypeSize);
+        }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public T Value { get; internal set; }

--- a/Ajuna.NetApi/Model/Types/Base/BaseEnumExt.cs
+++ b/Ajuna.NetApi/Model/Types/Base/BaseEnumExt.cs
@@ -60,6 +60,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
@@ -123,6 +124,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -186,6 +188,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
@@ -253,6 +256,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
@@ -322,6 +326,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
@@ -393,6 +398,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
@@ -466,6 +472,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
@@ -541,6 +548,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         public override string ToString() => JsonConvert.SerializeObject(Value);
@@ -618,6 +626,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -695,6 +704,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -774,6 +784,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -855,6 +866,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -938,6 +950,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1023,6 +1036,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1110,6 +1124,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1199,6 +1214,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1290,6 +1306,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1383,6 +1400,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1478,6 +1496,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1575,6 +1594,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1674,6 +1694,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1775,6 +1796,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1878,6 +1900,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -1983,6 +2006,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2090,6 +2114,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2199,6 +2224,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2310,6 +2336,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2423,6 +2450,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2538,6 +2566,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2655,6 +2684,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2774,6 +2804,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -2895,6 +2926,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3018,6 +3050,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3143,6 +3176,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3270,6 +3304,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3399,6 +3434,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3530,6 +3566,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3663,6 +3700,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3798,6 +3836,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -3935,6 +3974,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -4074,6 +4114,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -4215,6 +4256,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -4358,6 +4400,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -4503,6 +4546,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -4650,6 +4694,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -4799,6 +4844,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -4950,6 +4996,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -5103,6 +5150,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -5258,6 +5306,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -5415,6 +5464,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -5574,6 +5624,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -5735,6 +5786,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -5898,6 +5950,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -6063,6 +6116,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -6230,6 +6284,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -6399,6 +6454,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -6570,6 +6626,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -6743,6 +6800,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -6918,6 +6976,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -7095,6 +7154,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -7274,6 +7334,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -7455,6 +7516,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -7638,6 +7700,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -7823,6 +7886,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -8010,6 +8074,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -8199,6 +8264,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -8390,6 +8456,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -8583,6 +8650,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -8778,6 +8846,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -8975,6 +9044,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -9174,6 +9244,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -9375,6 +9446,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -9578,6 +9650,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -9783,6 +9856,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -9990,6 +10064,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -10199,6 +10274,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -10410,6 +10486,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -10623,6 +10700,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -10838,6 +10916,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -11055,6 +11134,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -11274,6 +11354,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -11495,6 +11576,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -11718,6 +11800,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -11943,6 +12026,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -12170,6 +12254,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -12399,6 +12484,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -12630,6 +12716,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -12863,6 +12950,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -13098,6 +13186,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -13335,6 +13424,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -13574,6 +13664,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -13815,6 +13906,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -14058,6 +14150,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -14303,6 +14396,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -14550,6 +14644,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -14799,6 +14894,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -15050,6 +15146,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -15303,6 +15400,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -15558,6 +15656,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -15815,6 +15914,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -16074,6 +16174,7 @@ namespace Ajuna.NetApi.Model.Types.Base
             Bytes = bytes.ToArray();
             Value = t;
             Value2 = value2;
+            TypeSize = 1 + value2.TypeSize;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/Ajuna.NetApi/Model/Types/Base/BaseTuple.cs
+++ b/Ajuna.NetApi/Model/Types/Base/BaseTuple.cs
@@ -27,6 +27,12 @@ namespace Ajuna.NetApi.Model.Types.Base
     public class BaseTuple<T1> : BaseType
                             where T1 : IType, new()
     {
+        public BaseTuple() { }
+        public BaseTuple(T1 t1)
+        {
+            Create(t1);
+        }
+
         public override string TypeName()
         {
             return "(" +
@@ -75,6 +81,12 @@ namespace Ajuna.NetApi.Model.Types.Base
                             where T1 : IType, new()
                             where T2 : IType, new()
     {
+        public BaseTuple() { }
+        public BaseTuple(T1 t1, T2 t2)
+        {
+            Create(t1, t2);
+        }
+
         public override string TypeName()
         {
             return "(" +
@@ -130,6 +142,12 @@ namespace Ajuna.NetApi.Model.Types.Base
                             where T2 : IType, new()
                             where T3 : IType, new()
     {
+        public BaseTuple() { }
+        public BaseTuple(T1 t1, T2 t2, T3 t3)
+        {
+            Create(t1, t2, t3);
+        }
+
         public override string TypeName()
         {
             return "(" +
@@ -192,6 +210,12 @@ namespace Ajuna.NetApi.Model.Types.Base
                             where T3 : IType, new()
                             where T4 : IType, new()
     {
+        public BaseTuple() { }
+        public BaseTuple(T1 t1, T2 t2, T3 t3, T4 t4)
+        {
+            Create(t1, t2, t3, t4);
+        }
+
         public override string TypeName()
         {
             return "(" +

--- a/Ajuna.NetApi/Model/Types/Base/BaseType.cs
+++ b/Ajuna.NetApi/Model/Types/Base/BaseType.cs
@@ -1,4 +1,7 @@
 ﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Ajuna.NetApi.Model.Types.Base
 {
@@ -30,5 +33,21 @@ namespace Ajuna.NetApi.Model.Types.Base
         public IType New() => this;
 
         public override string ToString() => JsonConvert.SerializeObject(this);
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is BaseType) || !obj.GetType().Equals(this.GetType()))
+                return false;
+
+            var baseType = (BaseType)obj;
+            return TypeSize == baseType.TypeSize &&
+                   TypeName() == baseType.TypeName() &&
+                   (Bytes == null && baseType.Bytes == null || Bytes.SequenceEqual(baseType.Bytes));
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(TypeSize, Bytes);
+        }
     }
 }

--- a/Ajuna.NetApi/Model/Types/Primitive/U128.cs
+++ b/Ajuna.NetApi/Model/Types/Primitive/U128.cs
@@ -5,7 +5,9 @@ namespace Ajuna.NetApi.Model.Types.Primitive
 {
     public class U128 : BasePrim<BigInteger>
     {
-        public U128() { }
+        public U128() {
+        }
+
         public U128(BigInteger value)
         {
             Create(value);
@@ -56,8 +58,8 @@ namespace Ajuna.NetApi.Model.Types.Primitive
         public void Create(BigInteger value)
         {
             // Ensure we have a positive number
-            if (value.Sign != 1)
-                throw new InvalidOperationException($"Unable to create a U256 instance while value is negative");
+            if (value.Sign < 0)
+                throw new InvalidOperationException($"Unable to create a {nameof(U128)} instance while value is negative");
 
             var byteArray = value.ToByteArray();
 

--- a/Ajuna.NetApi/Model/Types/Primitive/U256.cs
+++ b/Ajuna.NetApi/Model/Types/Primitive/U256.cs
@@ -54,8 +54,8 @@ namespace Ajuna.NetApi.Model.Types.Primitive
         public void Create(BigInteger value)
         {
             // Ensure we have a positive number
-            if (value.Sign != 1)
-                throw new InvalidOperationException($"Unable to create a U256 instance while value is negative");
+            if (value.Sign < 0)
+                throw new InvalidOperationException($"Unable to create a {nameof(U256)} instance while value is negative");
 
             var byteArray = value.ToByteArray();
 

--- a/Ajuna.NetApi/SubstrateClient.cs
+++ b/Ajuna.NetApi/SubstrateClient.cs
@@ -248,7 +248,7 @@ namespace Ajuna.NetApi
         /// <param name="callback"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public async Task<string> SubscribeStorageKeyAsync(string storageParams, Action<string, StorageChangeSet> callback, CancellationToken token)
+        public virtual async Task<string> SubscribeStorageKeyAsync(string storageParams, Action<string, StorageChangeSet> callback, CancellationToken token)
         {
             if (_socket?.State != WebSocketState.Open)
                 throw new ClientNotConnectedException($"WebSocketState is not open! Currently {_socket?.State}!");

--- a/Ajuna.NetApi/SubstrateClient.cs
+++ b/Ajuna.NetApi/SubstrateClient.cs
@@ -212,7 +212,7 @@ namespace Ajuna.NetApi
         /// <param name="parameters"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public async Task<T> GetStorageAsync<T>(string parameters, CancellationToken token) where T : IType, new()
+        public virtual async Task<T> GetStorageAsync<T>(string parameters, CancellationToken token) where T : IType, new()
         {
             return await GetStorageAsync<T>(parameters, null, token);
         }
@@ -224,7 +224,7 @@ namespace Ajuna.NetApi
         /// <param name="parameters"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public async Task<T> GetStorageAsync<T>(string parameters, string blockhash, CancellationToken token) where T : IType, new()
+        public virtual async Task<T> GetStorageAsync<T>(string parameters, string blockhash, CancellationToken token) where T : IType, new()
         {
             var str = await InvokeAsync<string>("state_getStorage", new object[] { parameters, blockhash }, token);
 
@@ -339,7 +339,7 @@ namespace Ajuna.NetApi
         /// <param name="parameters"> Options for controlling the operation. </param>
         /// <param name="token">      A token that allows processing to be cancelled. </param>
         /// <returns> A T. </returns>
-        public async Task<T> InvokeAsync<T>(string method, object parameters, CancellationToken token)
+        public virtual async Task<T> InvokeAsync<T>(string method, object parameters, CancellationToken token)
         {
             if (_socket?.State != WebSocketState.Open)
                 throw new ClientNotConnectedException($"WebSocketState is not open! Currently {_socket?.State}!");


### PR DESCRIPTION
- Added "virtual" to GetStorageAsync / InvokeAsync / SubscribeStorageKeyAsync methods to allow mocking.
- Override Equals method for basic type (BaseVec / BaseOpt / BaseTuple etc.)
- Fix TypeSize calc, because it was not filled in all cases
- Fix U128 and U256 bug I have introduced in my previous PR because I checked value was > 0 and should be >= 0