### PR TITLE
Handle U128 and U256 value when bytes are at the maximum

### DIFF
--- a/Substrate.NetApi.Test/TypeConverters/PrimitiveTypesTest.cs
+++ b/Substrate.NetApi.Test/TypeConverters/PrimitiveTypesTest.cs
@@ -184,6 +184,19 @@ namespace Substrate.NetApi.Test
             Assert.AreEqual(value, primImplicit);
         }
 
+        /// <summary>
+        /// From real use case here : https://mythos.subscan.io/block/2826170?tab=event&event=2826170-189
+        /// </summary>
+        [Test]
+        [TestCase("310789037729451024594500450253905211276")]
+        public void PrimU128_FromMaxBigIntegerValue_Test(string valueStr)
+        {
+            var value = BigInteger.Parse(valueStr);
+
+            var prim = new U128(value);
+            Assert.That(prim.Value, Is.EqualTo(value));
+        }
+
         [Test]
         public void PrimU128CreateTest()
         {
@@ -211,6 +224,15 @@ namespace Substrate.NetApi.Test
         {
             var number = new BigInteger(-1000);
             Assert.Throws<InvalidOperationException>(() => new U128(number));
+        }
+
+        [Test]
+        public void PrimU256_MaxValue()
+        {
+            BigInteger u256Max = BigInteger.Pow(2, 256) - 1;
+            var u256 = new U256(u256Max);
+
+            Assert.That(u256.Value, Is.EqualTo(u256Max));
         }
 
         [Test]

--- a/Substrate.NetApi.Test/TypeConverters/PrimitiveTypesTest.cs
+++ b/Substrate.NetApi.Test/TypeConverters/PrimitiveTypesTest.cs
@@ -236,6 +236,13 @@ namespace Substrate.NetApi.Test
         }
 
         [Test]
+        public void PrimU256_BasicNumberTest()
+        {
+            var u256 = new U256(new BigInteger(10));
+            Assert.That(u256.Value, Is.EqualTo(new BigInteger(10)));
+        }
+
+        [Test]
         public void PrimU256Test()
         {
             var value = BigInteger.Parse("452312821728632006638659744032470891714787547825123743022878680681856106495");

--- a/Substrate.NetApi/Model/Types/Primitive/U128.cs
+++ b/Substrate.NetApi/Model/Types/Primitive/U128.cs
@@ -97,7 +97,14 @@ namespace Substrate.NetApi.Model.Types.Primitive
             }
 
             var bytes = new byte[TypeSize];
-            Array.Copy(byteArray, 0, bytes, 0, TypeSize);
+            if (byteArray.Length == TypeSize + 1)
+            {
+                Array.Copy(byteArray, 0, bytes, 0, TypeSize);
+            }
+            else
+            {
+                byteArray.CopyTo(bytes, 0);
+            }
             Bytes = bytes;
             Value = value;
         }

--- a/Substrate.NetApi/Model/Types/Primitive/U128.cs
+++ b/Substrate.NetApi/Model/Types/Primitive/U128.cs
@@ -91,13 +91,13 @@ namespace Substrate.NetApi.Model.Types.Primitive
 
             var byteArray = value.ToByteArray();
 
-            if (byteArray.Length > TypeSize)
+            if (byteArray.Length > TypeSize + 1)
             {
                 throw new NotSupportedException($"Wrong byte array size for {TypeName()}, max. {TypeSize} bytes!");
             }
 
             var bytes = new byte[TypeSize];
-            byteArray.CopyTo(bytes, 0);
+            Array.Copy(byteArray, 0, bytes, 0, TypeSize);
             Bytes = bytes;
             Value = value;
         }

--- a/Substrate.NetApi/Model/Types/Primitive/U256.cs
+++ b/Substrate.NetApi/Model/Types/Primitive/U256.cs
@@ -92,14 +92,20 @@ namespace Substrate.NetApi.Model.Types.Primitive
                 throw new InvalidOperationException($"Unable to create a {nameof(U256)} instance while value is negative");
 
             var byteArray = value.ToByteArray();
-
+            
             if (byteArray.Length > TypeSize + 1)
             {
                 throw new NotSupportedException($"Wrong byte array size for {TypeName()}, max. {TypeSize} bytes!");
             }
 
             var bytes = new byte[TypeSize];
-            Array.Copy(byteArray, 0, bytes, 0, TypeSize);
+            if(byteArray.Length == TypeSize + 1) {
+                Array.Copy(byteArray, 0, bytes, 0, TypeSize);
+            }
+            else {
+                byteArray.CopyTo(bytes, 0);
+            }
+            
             Bytes = bytes;
             Value = value;
         }

--- a/Substrate.NetApi/Model/Types/Primitive/U256.cs
+++ b/Substrate.NetApi/Model/Types/Primitive/U256.cs
@@ -93,13 +93,13 @@ namespace Substrate.NetApi.Model.Types.Primitive
 
             var byteArray = value.ToByteArray();
 
-            if (byteArray.Length > TypeSize)
+            if (byteArray.Length > TypeSize + 1)
             {
                 throw new NotSupportedException($"Wrong byte array size for {TypeName()}, max. {TypeSize} bytes!");
             }
 
             var bytes = new byte[TypeSize];
-            byteArray.CopyTo(bytes, 0);
+            Array.Copy(byteArray, 0, bytes, 0, TypeSize);
             Bytes = bytes;
             Value = value;
         }


### PR DESCRIPTION
When creating a U128 or U256 number with BigInteger, the additional sign byte causes an error when the full byte array is used for data processing.